### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "reef"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "reef-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/reef-core", "crates/reef"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `reef-core`: 0.1.0 -> 0.1.1
* `reef`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>




</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).