### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.2.0] - 2026-08-20
+
+### Added
+- Fleet files, exposed ports, per-agent env
+- Add active ports to forward cmd, fix minor bugs
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "reef"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "reef-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/reef-core", "crates/reef"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `reef-core`: 0.1.1 -> 0.2.0
* `reef`: 0.1.1 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `reef`

<blockquote>

## [0.2.0] - 2026-08-20

### Added
- Fleet files, exposed ports, per-agent env
- Add active ports to forward cmd, fix minor bugs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).