### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.10.0] - 2026-09-03
+
+### Added
+- Update to msb 0.6.16
+- Add roles viewer to tui
+- Reef ui, a console over the --json rows
+- Implement [files] for roles
+- Add openclaw-browser role, add option to allow all hosts
+- Add serve cmd, add docs, update openclaw example
+- Add volumes support, update hermes reference
+- Non-destructive env patching
+- Fleet files, exposed ports, per-agent env
+- Add active ports to forward cmd, fix minor bugs
+
+### Fixed
+- Fix openclaw enterprise roles and the cloudflare access setup
+- Package publish
+- Package publish
+
+
 ## [0.9.0] - 2026-09-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "reef"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "reef-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/reef-core", "crates/reef"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"

--- a/crates/reef/Cargo.toml
+++ b/crates/reef/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4", features = ["derive", "env"] }
 flate2 = "1"
 microsandbox = { version = "=0.6.16", default-features = false, features = ["net", "prebuilt"] }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
-reef-core = { path = "../reef-core", version = "0.9.0" }
+reef-core = { path = "../reef-core", version = "0.10.0" }
 reqwest = "0.13"
 rusqlite = { version = "0.37", features = ["bundled"] }
 semver = "1"


### PR DESCRIPTION



## 🤖 New release

* `reef-core`: 0.9.0 -> 0.10.0
* `reef`: 0.9.0 -> 0.10.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `reef`

<blockquote>

## [0.10.0] - 2026-09-03

### Added
- Update to msb 0.6.16
- Add roles viewer to tui
- Reef ui, a console over the --json rows
- Implement [files] for roles
- Add openclaw-browser role, add option to allow all hosts
- Add serve cmd, add docs, update openclaw example
- Add volumes support, update hermes reference
- Non-destructive env patching
- Fleet files, exposed ports, per-agent env
- Add active ports to forward cmd, fix minor bugs

### Fixed
- Fix openclaw enterprise roles and the cloudflare access setup
- Package publish
- Package publish
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).